### PR TITLE
Pin Python version

### DIFF
--- a/.github/workflows/site.yaml
+++ b/.github/workflows/site.yaml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.x
+          python-version: "3.11"
       - run: pip install -r requirements.txt
       - run: mkdocs gh-deploy --force --remote-branch asf-site
       - run: |

--- a/docs/community/contributor_guide/build_and_test.md
+++ b/docs/community/contributor_guide/build_and_test.md
@@ -14,7 +14,7 @@ license: |
   limitations under the License.
 ---
 
-Buiding and Testing
+Building and Testing
 ===
 
 TODO


### PR DESCRIPTION
In Python 3.11.6 `pip install -r requirements.txt` succeeded, but failed in Python 3.12.0.

https://github.com/apache/incubator-celeborn-website/actions/runs/6648112513/job/18064645689
<img width="692" alt="image" src="https://github.com/apache/incubator-celeborn-website/assets/3898450/7734cd30-1565-49d8-8c2c-06d3fca47796">

https://github.com/apache/incubator-celeborn-website/actions/runs/6661600006/job/18104700958

<img width="705" alt="image" src="https://github.com/apache/incubator-celeborn-website/assets/3898450/f64a9aa4-dcd7-42ca-b17c-f423ac3e6464">
