### PR TITLE
Fix hero section layout responsiveness on mobile screens

### DIFF
--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -103,7 +103,7 @@
         display: block;
     }
 
-     @media screen and (max-width:30em) {
+    @media screen and (max-width:30em) {
         .tx-hero h1 {
             font-size: 1.4rem
         }

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -103,9 +103,35 @@
         display: block;
     }
 
-    @media screen and (max-width:30em) {
+     @media screen and (max-width:30em) {
         .tx-hero h1 {
             font-size: 1.4rem
+        }
+
+        .tx-hero {
+            margin: 20px 1rem;
+            display: flex;
+            flex-direction: column;
+            text-align: center;
+        }
+
+        .tx-hero__image {
+            width: 12rem;
+            height: 12rem;
+            padding-right: 0;
+            margin: 0 auto 1rem;
+            order: 0;
+        }
+
+        .tx-hero__content {
+            padding-bottom: 2rem;
+            order: 1;
+        }
+
+        .tx-hero .md-button {
+            display: inline-block;
+            margin: 0.5rem 0.25rem;
+            width: auto;
         }
     }
 


### PR DESCRIPTION
## Problem
- The hero section layout was not responsive on mobile screen sizes.
- There was an overflow in x direction in mobile screens.

## What Changes
- Centered logo and content on mobile screens
- Changed to vertical stack layout for small devices
- Logo size reduced from 17rem to 12rem on mobile

## Screenshots
### Before
<img width="300" alt="Screenshot 2026-01-22 054610" src="https://github.com/user-attachments/assets/ec9242fa-e7cc-43d4-808c-76a6c043ff0c" />
<img width="300" alt="Screenshot 2026-01-22 060402" src="https://github.com/user-attachments/assets/a8360b96-6c70-44a6-9c94-4febbcdd3344" />
<img width="300" alt="Screenshot 2026-01-22 060430" src="https://github.com/user-attachments/assets/39855fae-b6bc-44bb-89d5-3bad9e34f775" />


### After
<img width="300"  alt="Screenshot 2026-01-22 060326" src="https://github.com/user-attachments/assets/528bb933-503c-443d-997a-3839467df6b0" />
<img width="300" alt="Screenshot 2026-01-22 060411" src="https://github.com/user-attachments/assets/1e58851b-c49e-489a-9a31-d15b2564f62a" />
<img width="300" alt="Screenshot 2026-01-22 060435" src="https://github.com/user-attachments/assets/52930716-c644-4eb4-9fc2-03afe5369bd1" />